### PR TITLE
Adding trim methods from std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-pattern"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sergio Benitez <sb@sergio.bz>"]
 edition = "2018"
 description = "Stable port of std::str::Pattern and friends."

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -423,10 +423,7 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
     fn next_match(&mut self) -> Option<(usize, usize)> {
         loop {
             // get the haystack after the last character found
-            let bytes = self
-                .haystack
-                .as_bytes()
-                .get(self.finger..self.finger_back)?;
+            let bytes = self.haystack.as_bytes().get(self.finger..self.finger_back)?;
             // the last byte of the utf8 encoded needle
             // SAFETY: we have an invariant that `utf8_size < 5`
             let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size - 1) };
@@ -645,11 +642,7 @@ impl<'a, C: MultiCharEq> Pattern<'a> for MultiCharEqPattern<C> {
 
     #[inline]
     fn into_searcher(self, haystack: &'a str) -> MultiCharEqSearcher<'a, C> {
-        MultiCharEqSearcher {
-            haystack,
-            char_eq: self.0,
-            char_indices: haystack.char_indices(),
-        }
+        MultiCharEqSearcher { haystack, char_eq: self.0, char_indices: haystack.char_indices() }
     }
 }
 
@@ -808,11 +801,7 @@ impl<'a, 'b> DoubleEndedSearcher<'a> for CharSliceSearcher<'a, 'b> {}
 /// assert_eq!("Hello world".find(&['l', 'l'][..]), Some(2));
 /// ```
 impl<'a, 'b> Pattern<'a> for &'b [char] {
-    pattern_methods!(
-        CharSliceSearcher<'a, 'b>,
-        MultiCharEqPattern,
-        CharSliceSearcher
-    );
+    pattern_methods!(CharSliceSearcher<'a, 'b>, MultiCharEqPattern, CharSliceSearcher);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -864,11 +853,7 @@ impl<'a, F> Pattern<'a> for F
 where
     F: FnMut(char) -> bool,
 {
-    pattern_methods!(
-        CharPredicateSearcher<'a, F>,
-        MultiCharEqPattern,
-        CharPredicateSearcher
-    );
+    pattern_methods!(CharPredicateSearcher<'a, F>, MultiCharEqPattern, CharPredicateSearcher);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -1361,11 +1346,8 @@ impl TwoWaySearcher {
             }
 
             // See if the right part of the needle matches
-            let start = if long_period {
-                self.crit_pos
-            } else {
-                cmp::max(self.crit_pos, self.memory)
-            };
+            let start =
+                if long_period { self.crit_pos } else { cmp::max(self.crit_pos, self.memory) };
             for i in start..needle.len() {
                 if needle[i] != haystack[self.position + i] {
                     self.position += i - self.crit_pos + 1;
@@ -1464,11 +1446,7 @@ impl TwoWaySearcher {
             }
 
             // See if the right part of the needle matches
-            let needle_end = if long_period {
-                needle.len()
-            } else {
-                self.memory_back
-            };
+            let needle_end = if long_period { needle.len() } else { self.memory_back };
             for i in self.crit_pos_back..needle_end {
                 if needle[i] != haystack[self.end - needle.len() + i] {
                     self.end -= self.period;
@@ -1508,7 +1486,7 @@ impl TwoWaySearcher {
         let mut left = 0; // Corresponds to i in the paper
         let mut right = 1; // Corresponds to j in the paper
         let mut offset = 0; // Corresponds to k in the paper, but starting at 0
-                            // to match 0-based indexing.
+        // to match 0-based indexing.
         let mut period = 1; // Corresponds to p in the paper
 
         while let Some(&a) = arr.get(right + offset) {
@@ -1554,7 +1532,7 @@ impl TwoWaySearcher {
         let mut left = 0; // Corresponds to i in the paper
         let mut right = 1; // Corresponds to j in the paper
         let mut offset = 0; // Corresponds to k in the paper, but starting at 0
-                            // to match 0-based indexing.
+        // to match 0-based indexing.
         let mut period = 1; // Corresponds to p in the paper
         let n = arr.len();
 


### PR DESCRIPTION
Adding equivalent of `std::str::trim_start_matches` and `std::str::trim_end_matches`.

Not sure if there's anything else that'd be useful to add here, but I've found the `strip` methods super helpful on stable, and just ran into a scenario where the `trip` methods would also help. Let me know if you think this fits, or if there's anything else you'd like me to add here. Thanks!